### PR TITLE
#130 Skip ckeditor element from converting to select2 format

### DIFF
--- a/js/enable-select2.js
+++ b/js/enable-select2.js
@@ -16,7 +16,10 @@ CRM.$(function () {
    * during DOM changes
    */
   var observer = new MutationObserver(debounce(function () {
-    CRM.$('select:visible:not(.no-select2):not(.crm-form-multiselect)')
+    /*
+     * Skip Ckeditor element
+     */
+    CRM.$('select:visible:not(.no-select2):not(.crm-form-multiselect, .cke_dialog_ui_input_select)')
       .each(function () {
         var select = CRM.$(this);
         var hasNoSelect2Parent = select.closest('.no-select2').length;


### PR DESCRIPTION
CKEditor -> Link  (pop up appear) -> click on 'Link Type' list (it has 3 option) but not showing other 2 on click. To avoid such issue on non civicrm field, Exclude it.