### PR TITLE
Skip CKEditor element from converting to select2 format

### DIFF
--- a/js/enable-select2.js
+++ b/js/enable-select2.js
@@ -16,7 +16,10 @@ CRM.$(function () {
    * during DOM changes
    */
   var observer = new MutationObserver(debounce(function () {
-    CRM.$('select:visible:not(.no-select2):not(.crm-form-multiselect)')
+    /*
+     * Skip CKEditor element (.cke_dialog_ui_input_select)
+     */
+    CRM.$('select:visible:not(.no-select2):not(.crm-form-multiselect, .cke_dialog_ui_input_select)')
       .each(function () {
         var select = CRM.$(this);
         var hasNoSelect2Parent = select.closest('.no-select2').length;


### PR DESCRIPTION
Use any form where ckeditor  load -> Click on Link  (pop up box appear) -> Click on Link Type -> It should show list.

> Before
Field converted to Select 2 Style. Drop down list not available (because of Z-index issue)
<img width="775" alt="before" src="https://user-images.githubusercontent.com/377735/34670825-f4d29a36-f49d-11e7-9252-317d941b076b.png">

> After
Skipping the CKEditor element from converting to select 2 style.
Select option easily available without any issue.
<img width="854" alt="after" src="https://user-images.githubusercontent.com/377735/34670897-3cf67986-f49e-11e7-9c7e-1a6d6022274d.png">

